### PR TITLE
Fixed text not initially hiding with In effects.

### DIFF
--- a/jquery.textillate.js
+++ b/jquery.textillate.js
@@ -106,9 +106,9 @@
         .text(base.$texts.find(':first-child').html())
         .prependTo($element);
 
-      if (isInEffect(options.effect)) {
+      if (isInEffect(options.in.effect)) {
         base.$current.css('visibility', 'hidden');
-      } else if (isOutEffect(options.effect)) {
+      } else if (isOutEffect(options.out.effect)) {
         base.$current.css('visibility', 'visible');
       }
 


### PR DESCRIPTION
With an initialDelay of say 5 seconds, text would be shown for 5 seconds before being hidden for a fade or some other In effect in to start. With a zero initialDelay, this was rarely noticeable, but sometimes a flash was seen with the text.
