### PR TITLE
possible to specify options via data- attributes

### DIFF
--- a/jquery.textillate.js
+++ b/jquery.textillate.js
@@ -25,14 +25,21 @@
     if (!attrs.length) return data;
 
     $.each(attrs, function (i, attr) {
-      if (/^data-in-*/.test(attr.nodeName)) {
+
+      function stringToBoolean(str) {
+          if (str !== "true" && str !== "false") return str;
+		  return (str === "true");
+	  }
+	  
+	  var nodeName = attr.nodeName.replace(/delayscale/, 'delayScale');
+      if (/^data-in-*/.test(nodeName)) {
         data.in = data.in || {};
-        data.in[attr.nodeName.replace(/data-in-/, '')] = attr.nodeValue;
-      } else if (/^data-out-*/.test(attr.nodeName)) {
+        data.in[nodeName.replace(/data-in-/, '')] = stringToBoolean(attr.nodeValue);
+      } else if (/^data-out-*/.test(nodeName)) {
         data.out = data.out || {};
-        data.out[attr.nodeName.replace(/data-out-/, '')] = attr.nodeValue;
-      } else if (/^data-*/.test(attr.nodeName)) {
-        data[attr.nodeName] = attr.nodeValue;
+        data.out[nodeName.replace(/data-out-/, '')] =stringToBoolean(attr.nodeValue);
+      } else if (/^data-*/.test(nodeName)) {
+        data[nodeName] = stringToBoolean(attr.nodeValue);
       }
     })
 
@@ -135,7 +142,7 @@
       index = index || 0;
        
       var $elem = base.$texts.find(':nth-child(' + (index + 1) + ')')
-        , options = $.extend({}, base.options, getData($elem))
+        , options = $.extend(true, {}, base.options, $elem.length?getData($elem[0]):{})
         , $chars;
 
       $elem.addClass('current');
@@ -179,7 +186,7 @@
     base.out = function (cb) {
       var $elem = base.$texts.find(':nth-child(' + (base.currentIndex + 1) + ')')
         , $chars = base.$current.find('[class^="char"]')
-        , options = $.extend({}, base.options, getData($elem));
+        , options = $.extend(true, {}, base.options, $elem.length?getData($elem[0]):{})
 
       base.triggerEvent('outAnimationBegin');
 


### PR DESCRIPTION
Hi, it seems that jquery.find returns an array instead of a single element. This prevented textillate from reading the options specified in the <li> elements.

This patch fixes that error. Also, it converts "true"/"false" to true/false in the case of data-in-shuffle etc., and handles situation where data-in-delayScale is forcibly changed to lower case. This makes it possible to specify those options as well.
