### PR TITLE
removed redundant dark.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Textillate.js</title>
   <link href="assets/animate.css" rel="stylesheet">
-  <link href="assets/dark.css" rel="stylesheet">
   <link href="assets/style.css" rel="stylesheet">
   <link href='http://fonts.googleapis.com/css?family=Rokkitt' rel='stylesheet' type='text/css'>
   <body>


### PR DESCRIPTION
I noticed that the dark theme was merged into another file, so there's no need for the link in the head. 
