### PR TITLE
fix(initially): fixes init delay on manual start

### DIFF
--- a/jquery.textillate.js
+++ b/jquery.textillate.js
@@ -199,7 +199,8 @@
     };
 
     base.start = function (index) {
-      base.triggerEvent('start');
+      setTimeout(function () {
+        base.triggerEvent('start');
 
       (function run (index) {
         base.in(index, function () {
@@ -221,6 +222,7 @@
           }
         });
       }(index || 0));
+      }, base.options.initialDelay); 
     };
 
     base.stop = function () {


### PR DESCRIPTION
I've seen that when the autostart is set to false the initial delay is not being taken
